### PR TITLE
storage: use connection string for postgres

### DIFF
--- a/gtfs_test.go
+++ b/gtfs_test.go
@@ -1,0 +1,9 @@
+package gtfs_test
+
+// Most tests in this package run against the in-memory and storage
+// backends by default. If PostgresConnStr is set, they'll also run
+// against postgres.
+
+const (
+	PostgresConnStr = "" // "postgres://postgres:mysecretpassword@localhost:5432/gtfs?sslmode=disable"
+)

--- a/realtime_integration_test.go
+++ b/realtime_integration_test.go
@@ -72,8 +72,6 @@ func TestRealtimeIntegrationNYCFerryDelaysOnER(t *testing.T) {
 		},
 	}, departures)
 
-	fmt.Println("Failure below")
-
 	// Makes sure delay got propagated to Dumbo.
 	//
 	// Minor note: the original schedule has this departing 11:13,

--- a/realtime_test.go
+++ b/realtime_test.go
@@ -29,17 +29,9 @@ func staticAndReaderFromFiles(t *testing.T, backend string, files map[string][]s
 		s, err = storage.NewSQLiteStorage()
 		require.NoError(t, err)
 	} else if backend == "postgres" {
-		s, err = storage.NewPSQLStorage(storage.PSQLConfig{
-			Host:     "localhost",
-			Port:     5432,
-			User:     "postgres",
-			Password: "mysecretpassword",
-			DBName:   "gtfs",
-			ClearDB:  true,
-		})
+		s, err = storage.NewPSQLStorage(PostgresConnStr, true)
 		require.NoError(t, err)
 	} else {
-
 		t.Fatalf("Unknown backend: %s", backend)
 	}
 

--- a/static_integration_test.go
+++ b/static_integration_test.go
@@ -22,14 +22,7 @@ func loadFeed2(t *testing.T, backend string, filename string) (*gtfs.Static, sto
 		s, err = storage.NewSQLiteStorage()
 		require.NoError(t, err)
 	} else if backend == "postgres" {
-		s, err = storage.NewPSQLStorage(storage.PSQLConfig{
-			Host:     "localhost",
-			Port:     5432,
-			User:     "postgres",
-			Password: "mysecretpassword",
-			DBName:   "gtfs",
-			ClearDB:  true,
-		})
+		s, err = storage.NewPSQLStorage(PostgresConnStr, true)
 		require.NoError(t, err)
 	} else {
 		t.Fatalf("unknown backend %q", backend)
@@ -247,8 +240,10 @@ func TestStaticIntegration(t *testing.T) {
 		t.Run(test.Name+"_memory", func(t *testing.T) {
 			test.Test(t, "memory")
 		})
-		// t.Run(test.Name+"_postgres", func(t *testing.T) {
-		//	test.Test(t, "postgres")
-		// })
+		if PostgresConnStr != "" {
+			t.Run(test.Name+"_postgres", func(t *testing.T) {
+				test.Test(t, "postgres")
+			})
+		}
 	}
 }

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -17,6 +17,14 @@ import (
 	"tidbyt.dev/gtfs/storage"
 )
 
+// Tests of the storage implementations. The in-memory and sqlite
+// implementations are always run, while postgres require the
+// PostgresConnStr below to be set.
+
+const (
+	PostgresConnStr = "" // "postgres://postgres:mysecretpassword@localhost:5432/gtfs?sslmode=disable"
+)
+
 type StorageBuilder func() (storage.Storage, error)
 
 func readerFromFiles(t *testing.T, sb StorageBuilder, files map[string][]string) storage.FeedReader {
@@ -2071,19 +2079,12 @@ func TestStorage(t *testing.T) {
 				return storage.NewSQLiteStorage(storage.SQLiteConfig{OnDisk: true, Directory: dir})
 			})
 		})
-		/*
+		if PostgresConnStr != "" {
 			t.Run(fmt.Sprintf("%s Postgres", test.Name), func(t *testing.T) {
 				test.Test(t, func() (storage.Storage, error) {
-					return storage.NewPSQLStorage(storage.PSQLConfig{
-						Host:     "localhost",
-						Port:     5432,
-						User:     "postgres",
-						Password: "mysecretpassword",
-						DBName:   "gtfs",
-						ClearDB:  true,
-					})
+					return storage.NewPSQLStorage(PostgresConnStr, true)
 				})
 			})
-		*/
+		}
 	}
 }

--- a/whitebox_test.go
+++ b/whitebox_test.go
@@ -1,0 +1,126 @@
+package gtfs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Don't love this, but some internal functions are finicky and need
+// testing.
+
+func TestStaticRangePerDate(t *testing.T) {
+	tzET, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+
+	// Eastern daylight savings started March 12th, 2023. At 2PM
+	// it became 3PM.
+
+	// Eastern standard time started November 5th, 2023. At 2AM
+	// it became 1AM.
+
+	for _, tc := range []struct {
+		Name     string
+		Start    time.Time
+		Window   time.Duration
+		Max      time.Duration
+		Expected []span
+	}{
+		{
+			"simple",
+			time.Date(2023, 2, 3, 6, 0, 0, 0, tzET),
+			30 * time.Minute,
+			1 * time.Hour,
+			[]span{{"20230203", "060000", "063000"}},
+		},
+
+		{
+			"past midnight",
+			time.Date(2023, 2, 3, 6, 0, 0, 0, tzET),
+			30 * time.Hour,
+			1 * time.Hour,
+			[]span{
+				{"20230203", "060000", ""},
+				{"20230204", "", "120000"},
+			},
+		},
+
+		{
+			"past midnight, with change to daylight savings time",
+			time.Date(2023, 3, 11, 6, 0, 0, 0, tzET),
+			30 * time.Hour,
+			1 * time.Hour,
+			[]span{
+				{"20230311", "060000", ""},
+				{"20230312", "", "130000"},
+			},
+		},
+
+		{
+			"past midnight, with change to standard time",
+			time.Date(2023, 11, 4, 6, 0, 0, 0, tzET),
+			30 * time.Hour,
+			1 * time.Hour,
+			[]span{
+				{"20231104", "060000", ""},
+				{"20231105", "", "110000"},
+			},
+		},
+
+		{
+			"multiple days",
+			time.Date(2023, 2, 3, 6, 0, 0, 0, tzET),
+			49 * time.Hour,
+			1 * time.Hour,
+			[]span{
+				{"20230203", "060000", ""},
+				{"20230204", "", ""},
+				{"20230205", "", "070000"},
+			},
+		},
+
+		{
+			"maxTrip indicating overflow from previous day",
+			time.Date(2023, 2, 3, 6, 0, 0, 0, tzET),
+			2 * time.Hour,
+			(24 + 7) * time.Hour,
+			[]span{
+				{"20230202", "300000", ""},
+				{"20230203", "060000", "080000"},
+			},
+		},
+
+		{
+			"overflow precisely touching range",
+			time.Date(2023, 2, 3, 6, 0, 0, 0, tzET),
+			2 * time.Hour,
+			(24 + 6) * time.Hour,
+			[]span{
+				{"20230202", "300000", ""},
+				{"20230203", "060000", "080000"},
+			},
+		},
+
+		{
+			"multi day with overflow reaching end of range",
+			time.Date(2023, 2, 3, 6, 0, 0, 0, tzET),
+			(48+18)*time.Hour + 30*time.Minute,
+			(24 + 1) * time.Hour,
+			[]span{
+				{"20230203", "060000", ""},
+				{"20230204", "", ""},
+				{"20230205", "", "243000"},
+				{"20230206", "", "003000"},
+			},
+		},
+
+		// TODO: write a test of overflow with DST change
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			spans := rangePerDate(tc.Start, tc.Window, tc.Max)
+			assert.Equal(t, tc.Expected, spans)
+		})
+	}
+}


### PR DESCRIPTION
Relatively minor change in storage forcing a lot of stuff to be reshuffled in tests.